### PR TITLE
Hot-fix: bad gateway 502 by replacing undefined $realpath_root with built…

### DIFF
--- a/docker/dev/nginx/conf.d/default.conf
+++ b/docker/dev/nginx/conf.d/default.conf
@@ -27,8 +27,8 @@ server {
         # Otherwise, PHP's OPcache may not properly detect changes to
         # your PHP files (see https://github.com/zendtech/ZendOptimizerPlus/issues/126
         # for more information).
-        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
-        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $document_root;
         fastcgi_read_timeout 3000;
 
         fastcgi_buffers 16 32k;


### PR DESCRIPTION
fixed bad gateway 502 issue by replacing undefined $realpath_root with built-in $document_root in Nginx config.